### PR TITLE
Fix canvas toDataURL() enlarge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,22 @@ Define the Cropper.js options.
 Define the crop image max width.
 
 
+#### maxHeight
+
+* Type: `Number|null`
+* Default: `null`
+
+Define the crop image max height.
+
+
+#### imageMimeType
+
+* Type: `String`
+* Default: `'auto'`
+
+Define the cropped image Mime-Type, If set `'auto'` will guess the image Mime-Type, or force set the Mime-Type, Ex: `image/jpeg`.
+
+
 #### action
 
 * Type: `String|null`

--- a/src/index.js
+++ b/src/index.js
@@ -238,6 +238,7 @@ if ($.fn) {
       },
       maxWidth: null,
       maxHeight: null,
+      imageMimeType: 'auto',
 
       // Upload
       uploadFile: null,
@@ -284,6 +285,35 @@ if ($.fn) {
 
     const onOpen = settings.onOpen
     settings.onOpen = () => {
+      if (settings.imageMimeType === 'auto') {
+        try {
+          // check is is base64 or not (throw exception)
+          atob(settings.src.split(',')[1])
+  
+          // is base64
+          settings.imageMimeType = settings.src.split(':')[1].split(';')[0]
+        } catch (error) {
+          if (error instanceof DOMException) {
+            // is image
+            const mimetypeMap = {
+              jpg: 'image/jpeg',
+              jpeg: 'image/jpeg',
+              png: 'image/png',
+              gif: 'image/gif',
+              svg: 'image/svg+xml',
+              webp: 'image/webp',
+            }
+            const m = settings.src.match(/\.(\w+)$/)
+            settings.imageMimeType = mimetypeMap[m && m[1]]
+          }
+        }
+
+        // If guess is not working, return the default mime-type
+        if (settings.imageMimeType === 'auto') {
+          settings.imageMimeType = 'image/jpeg'
+        }
+      }
+
       cropper = new Cropper(image.get(0), settings.cropper)
       if (onOpen) onOpen()
     }
@@ -292,7 +322,7 @@ if ($.fn) {
     settings.onOk = () => {
       if (onOk) onOk()
 
-      const croppedDataURL = cropper.getCroppedCanvas().toDataURL()
+      const croppedDataURL = cropper.getCroppedCanvas().toDataURL(settings.imageMimeType)
       cropper.destroy()
 
       // Renew image size


### PR DESCRIPTION
Fix #6.

Add option [`imageMimeType`](https://github.com/ycs77/jquery-plugin-bsModal#imagemimetype), default is `'auto'`, or set the Mime-Type with cropped image, example:

```js
$('#cropImageBtn').bsModalCropper({
  id: 'bsModalCropper',
  title: 'Crop image',
  src: 'https://ycs77.github.io/jquery-plugin-bsModal/example-picture.jpg',

  ...

  imageMimeType: 'image/jpeg'
});
```